### PR TITLE
Word click

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -40,13 +40,19 @@
 			const response = await fetchSyns();
 			const items = response[0].meta.syns[0];
 			foundWords = items;
-			loading = false;
 			console.log(foundWords);
+			loading = false;
 		} catch(error) {
 				loading = false;
 				errorMsg = 'There was a problem getting your synonyms. Please try again.';
 				console.log(error);
 		}
+	};
+
+	const handleClick = ({ target }) => {
+		const { id } = target;
+		curWord = id;
+		grabSyns();
 	};
 
 </script>
@@ -73,7 +79,7 @@
 	{:else}
 		<div class="word-wrapper">
 			{#each foundWords as word}
-				<p id={word} class="word">{word}</p>
+				<p id={word} class="word" on:click={e => handleClick(e)}>{word}</p>
 			{/each}
 		</div>
 	{/if}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,7 +74,7 @@
 		<div class="word-wrapper">
 			{#each foundWords as word}
 				<p id={word} class="word">{word}</p>
-				{/each}
+			{/each}
 		</div>
 	{/if}
 </main>
@@ -151,6 +151,8 @@
 
 	.word {
 		cursor: pointer;
+		user-select: none;
+		-moz-user-select: none;
 	}
 
 	.word:hover {
@@ -256,7 +258,7 @@
 	  top: 56px;
 	  left: 12px;
 	}
-	
+
 	@keyframes lds-roller {
 	  0% {
 	    transform: rotate(0deg);


### PR DESCRIPTION
### What does this PR do? 

- Allows rendered synonyms to be clickable.
- Adds additional styling to synonyms. 

----------

### How to manually test: 

- `git fetch`
- 'git checkout word-click`
- `npm run dev`
- Open the app on localhost:5000, search a word, click on a rendered synonym. The words hsould be searched and displayed in the input after being clicked. 

----------

### Tickets: 

- Resolves #5 